### PR TITLE
Added to update function in transactionServiceImpl and Bugs

### DIFF
--- a/src/main/java/com/lambdaschool/tiemendo/controller/TransactionController.java
+++ b/src/main/java/com/lambdaschool/tiemendo/controller/TransactionController.java
@@ -71,8 +71,8 @@ public class TransactionController {
             @RequestBody Transaction updateTransaction,
             @PathVariable long transactionId
     ) {
-        transactionService.update(updateTransaction, transactionId);
-        return new ResponseEntity<>(HttpStatus.OK);
+        Transaction t = transactionService.update(updateTransaction, transactionId);
+        return new ResponseEntity<>(t,HttpStatus.OK);
     }
 
     @ApiOperation(value = "Deletes transaction based on transaction id.", response = Transaction.class)

--- a/src/main/java/com/lambdaschool/tiemendo/service/TransactionServiceImpl.java
+++ b/src/main/java/com/lambdaschool/tiemendo/service/TransactionServiceImpl.java
@@ -96,6 +96,7 @@ public class TransactionServiceImpl implements TransactionService
 
             for(TransactionItem i: originalInputs) {
                 necessaryArrayList.add(i);
+                i.setTransaction(currentTransaction);//setting current transaction in updated transaction-items constructor
             }
 
             currentTransaction.setInputs(necessaryArrayList);


### PR DESCRIPTION
1) It appears that the transactionServiceImpl *update* function also needed the change made earlier to the *save* function (aka  i.setTransaction(newTransaction))

2) *Updating transactions is still buggy*. With the current configuration of the service, sending a PUT update with *only one* item to an existing transaction with (for example) 2 items does not result in an updated transaction with 1 item and a  *new total*.  

Instead, we get all items that were ever associated with that transaction and the new cumulative total. Seems like we need to discuss how to handle existing items associated with a transaction if they are no longer desired in an updated trasaction.

3)I think the  update transaction form needs to be able to send empty objects for fields that the user does not want to update. Currently the items array always has an object with empty strings.  This results in some wonky errors if you send updates with no item specified.

That's all for now.