### PR TITLE
Transaction Update Fix

### DIFF
--- a/src/main/java/com/lambdaschool/tiemendo/repository/TransactionItemRepository.java
+++ b/src/main/java/com/lambdaschool/tiemendo/repository/TransactionItemRepository.java
@@ -4,5 +4,8 @@ package com.lambdaschool.tiemendo.repository;
 import com.lambdaschool.tiemendo.model.TransactionItem;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
-public interface TransactionItemRepository extends PagingAndSortingRepository<TransactionItem, Long> {
+public interface TransactionItemRepository extends PagingAndSortingRepository<TransactionItem, Long>
+{
+    @Override
+    void deleteAll(Iterable<? extends TransactionItem> iterable);
 }

--- a/src/main/java/com/lambdaschool/tiemendo/service/ClientServiceImpl.java
+++ b/src/main/java/com/lambdaschool/tiemendo/service/ClientServiceImpl.java
@@ -40,8 +40,8 @@ public class ClientServiceImpl implements ClientService {
 
         // TODO - add in implementation for pageable and sort
 
-        if (keys.contains("isLead") && searchFields.get("isLead") != null) {
-            lead = Boolean.valueOf(searchFields.get("isLead"));
+        if (keys.contains("lead") && searchFields.get("lead") != null) {
+            lead = Boolean.valueOf(searchFields.get("lead"));
         }
 
         if (keys.contains("type") && searchFields.get("type") != null) {

--- a/src/main/java/com/lambdaschool/tiemendo/service/TransactionServiceImpl.java
+++ b/src/main/java/com/lambdaschool/tiemendo/service/TransactionServiceImpl.java
@@ -8,6 +8,7 @@ import com.lambdaschool.tiemendo.model.Transaction;
 
 import com.lambdaschool.tiemendo.model.TransactionItem;
 import com.lambdaschool.tiemendo.repository.ClientRepository;
+import com.lambdaschool.tiemendo.repository.TransactionItemRepository;
 import com.lambdaschool.tiemendo.repository.TransactionRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -28,6 +29,8 @@ public class TransactionServiceImpl implements TransactionService
     @Autowired
     ClientRepository clientRepository;
 
+    @Autowired
+    TransactionItemRepository transactionItemRepository;
 
     @Override
     public Page<Transaction> findAll(Pageable pageable)
@@ -112,11 +115,15 @@ public class TransactionServiceImpl implements TransactionService
             ArrayList necessaryArrayList = new ArrayList();
             List<TransactionItem> originalInputs = transaction.getInputs();
 
-            for(TransactionItem i: originalInputs) {
+            for(TransactionItem i: originalInputs)
+            {
                 necessaryArrayList.add(i);
                 i.setTransaction(currentTransaction);//setting current transaction in updated transaction-items constructor
             }
-
+            //need to remove existing items, since full list including old items will be added in
+            //orphan removal was causing error, have to delete all manually and replace
+            transactionItemRepository.deleteAll(currentTransaction.getInputs());
+            currentTransaction.getInputs().clear();
             currentTransaction.setInputs(necessaryArrayList);
         }
 


### PR DESCRIPTION
Orphan removal was causing an error, so had to delete manually. Also, transaction.setItems was not replacing array, just adding new array onto it, so process is:
1: delete existing TransactionItems from database
2: Remove them from the (soon to be) updated Transaction that will be saved
3: Add the updated list of Transaction items to the transaction
4: save the transaction, committing the updated list to the database